### PR TITLE
Matching verbs and nouns so sentences make sense

### DIFF
--- a/app/models/noun.rb
+++ b/app/models/noun.rb
@@ -1,2 +1,4 @@
 class Noun < ApplicationRecord
+  has_many :verb_noun_links
+  has_many :verbs, through: :verb_noun_links, dependent: :destroy
 end

--- a/app/models/structure_element.rb
+++ b/app/models/structure_element.rb
@@ -1,5 +1,5 @@
 class StructureElement < ApplicationRecord
   belongs_to :structure
   belongs_to :element
-  validates :position, presence: true
+  validates :position, :element_id, :structure_id, presence: true
 end

--- a/app/models/verb.rb
+++ b/app/models/verb.rb
@@ -1,2 +1,4 @@
 class Verb < ApplicationRecord
+  has_many :verb_noun_links
+  has_many :nouns, through: :verb_noun_links, dependent: :destroy
 end

--- a/app/models/verb_noun_link.rb
+++ b/app/models/verb_noun_link.rb
@@ -1,0 +1,5 @@
+class VerbNounLink < ApplicationRecord
+  belongs_to :noun
+  belongs_to :verb
+  validates :noun_id, :verb_id, presence: true
+end

--- a/app/services/sentence_builder_service.rb
+++ b/app/services/sentence_builder_service.rb
@@ -1,5 +1,5 @@
 class SentenceBuilderService
-  PERSON = %w[first_singular second_singular third_masculin third_feminin third_neutral first_plurial second_plurial third_plurial]
+  PERSON = %w[first_singular second_singular third_masculin third_feminin first_plurial second_plurial third_plurial]
   GENDER = %w[masculin feminin neutral plurial]
 
   def initialize(exercise)
@@ -30,11 +30,11 @@ class SentenceBuilderService
 
   def fetch_verb
     if @person[0..4] == 'third' && @person != 'third_plurial'
-      verb = Verb.where(person: 'third_singular', g_case: @g_case).sample
-      return { german: verb.value, english: verb.english }
+      @verb_instance = Verb.where(person: 'third_singular', g_case: @g_case).sample
+      return { german: @verb_instance.value, english: @verb_instance.english }
     end
-    verb = Verb.where(person: @person, g_case: @g_case).sample
-    { german: verb.value, english: verb.english }
+    @verb_instance = Verb.where(person: @person, g_case: @g_case).sample
+    { german: @verb_instance.value, english: @verb_instance.english }
   end
 
   def fetch_article
@@ -43,7 +43,7 @@ class SentenceBuilderService
   end
 
   def fetch_noun
-    noun = Noun.where(gender: @gender).sample
+    noun = @verb_instance.nouns.all.sample
     { german: noun.value, english: noun.english }
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: grammar_blitz_test
+  database: Grammar_Blitz_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/database.yml
+++ b/config/database.yml
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: Grammar_Blitz_test
+  database: grammar_blitz_test
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/db/migrate/20191111163641_create_verb_noun_links.rb
+++ b/db/migrate/20191111163641_create_verb_noun_links.rb
@@ -1,0 +1,10 @@
+class CreateVerbNounLinks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :verb_noun_links do |t|
+      t.references :noun, foreign_key: true
+      t.references :verb, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191112100304_add_is_a_to_noun.rb
+++ b/db/migrate/20191112100304_add_is_a_to_noun.rb
@@ -1,0 +1,5 @@
+class AddIsAToNoun < ActiveRecord::Migration[5.2]
+  def change
+    add_column :nouns, :is_a, :string
+  end
+end

--- a/db/migrate/20191112100909_add_go_with_to_verbs.rb
+++ b/db/migrate/20191112100909_add_go_with_to_verbs.rb
@@ -1,0 +1,5 @@
+class AddGoWithToVerbs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :verbs, :go_with, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_11_100334) do
+ActiveRecord::Schema.define(version: 2019_11_12_100909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2019_11_11_100334) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "english"
+    t.string "is_a"
   end
 
   create_table "personal_pronouns", force: :cascade do |t|
@@ -101,6 +102,15 @@ ActiveRecord::Schema.define(version: 2019_11_11_100334) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "verb_noun_links", force: :cascade do |t|
+    t.bigint "noun_id"
+    t.bigint "verb_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["noun_id"], name: "index_verb_noun_links_on_noun_id"
+    t.index ["verb_id"], name: "index_verb_noun_links_on_verb_id"
+  end
+
   create_table "verbs", force: :cascade do |t|
     t.string "value"
     t.string "person"
@@ -109,6 +119,7 @@ ActiveRecord::Schema.define(version: 2019_11_11_100334) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "english"
+    t.string "go_with", array: true
   end
 
   add_foreign_key "exercices", "structures"
@@ -116,4 +127,6 @@ ActiveRecord::Schema.define(version: 2019_11_11_100334) do
   add_foreign_key "progress_trackers", "users"
   add_foreign_key "structure_elements", "elements"
   add_foreign_key "structure_elements", "structures"
+  add_foreign_key "verb_noun_links", "nouns"
+  add_foreign_key "verb_noun_links", "verbs"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,10 +7,11 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 ProgressTracker.delete_all
 User.delete_all
+VerbNounLink.delete_all
 Verb.delete_all
+Noun.delete_all
 PersonalPronoun.delete_all
 Article.delete_all
-Noun.delete_all
 StructureElement.delete_all
 Element.delete_all
 Exercice.delete_all
@@ -22,24 +23,24 @@ User.create!(
   )
 
 verbs = [
-      %w[bin first_singular sein auxiliary am],
-      %w[bist second_singular sein auxiliary are],
-      %w[ist third_singular sein auxiliary is],
-      %w[sind first_plurial sein auxiliary are],
-      %w[seid second_plurial sein auxiliary are],
-      %w[sind third_plurial sein auxiliary are],
-      %w[kenne first_singular kennen accusative know],
-      %w[kennst second_singular kennen accusative know],
-      %w[kennt third_singular kennen accusative knows],
-      %w[kennen first_plurial kennen accusative know],
-      %w[kennt second_plurial kennen accusative know],
-      %w[kennen third_plurial kennen accusative know],
-      %w[kaufe first_singular kaufen accusative buy],
-      %w[kaufst second_singular kaufen accusative buy],
-      %w[kauft third_singular kaufen accusative buys],
-      %w[kaufen first_plurial kaufen accusative buy],
-      %w[kauft second_plurial kaufen accusative buy],
-      %w[kaufen third_plurial kaufen accusative buy]
+      %w[bin first_singular sein auxiliary am] << %w[people],
+      %w[bist second_singular sein auxiliary are] << %w[people],
+      %w[ist third_singular sein auxiliary is] << %w[people],
+      %w[sind first_plurial sein auxiliary are] << %w[people],
+      %w[seid second_plurial sein auxiliary are] << %w[people],
+      %w[sind third_plurial sein auxiliary are] << %w[people],
+      %w[kenne first_singular kennen accusative know] << %w[people place object],
+      %w[kennst second_singular kennen accusative know] << %w[people place object],
+      %w[kennt third_singular kennen accusative knows] << %w[people place object],
+      %w[kennen first_plurial kennen accusative know] << %w[people place object],
+      %w[kennt second_plurial kennen accusative know] << %w[people place object],
+      %w[kennen third_plurial kennen accusative know] << %w[people place object],
+      %w[kaufe first_singular kaufen accusative buy] << %w[food object animal vehicule building],
+      %w[kaufst second_singular kaufen accusative buy] << %w[food object animal vehicule building],
+      %w[kauft third_singular kaufen accusative buys] << %w[food object animal vehicule building],
+      %w[kaufen first_plurial kaufen accusative buy] << %w[food object animal vehicule building],
+      %w[kauft second_plurial kaufen accusative buy] << %w[food object animal vehicule building],
+      %w[kaufen third_plurial kaufen accusative buy] << %w[food object animal vehicule building]
       ]
 
 verbs.each do |array|
@@ -48,15 +49,54 @@ verbs.each do |array|
     person: array[1],
     preterit: array[2],
     g_case: array[3],
-    english: array[4]
+    english: array[4],
+    go_with: array[5]
     )
+end
+
+noun = [
+  %w[freund masculin friend people],
+  %w[mann masculin man people],
+  %w[kellner masculin waiter people],
+  %w[freundin feminin friend people],
+  %w[stadt feminin city place],
+  %w[hand feminin hand],
+  %w[hande plurial hands body],
+  %w[teile plurial parts object],
+  %w[manner plurial men people],
+  %w[lander plurial countries place],
+  %w[auto neutral car vehicule],
+  %w[jahr neutral year time],
+  %w[pizza feminin pizza food],
+  %w[kurbis masculin pumpkin food],
+  %w[haus neutral house building],
+  ]
+
+noun.each do |array|
+  Noun.create!(
+    value: array[0],
+    gender: array[1],
+    english: array[2],
+    is_a: array[3]
+      )
+end
+noun_instances = Noun.all
+verb_instances = Verb.all
+verb_instances.each do |verb|
+  noun_instances.each do |noun|
+    if verb.go_with.include?(noun.is_a)
+      VerbNounLink.create!(
+        verb_id: verb.id,
+        noun_id: noun.id
+        )
+    end
+  end
 end
 
 pp = [%w[ich first_singular nominative I],
       %w[du second_singular nominative you],
       %w[er third_masculin nominative he],
       %w[sie third_feminin nominative she],
-      %w[es third_neutral nominative it],
       %w[wir first_plurial nominative we],
       %w[ihr second_plurial nominative you],
       %w[Sie third_plurial nominative they],
@@ -91,31 +131,6 @@ da.each do |array|
       )
 end
 
-noun = [
-  %w[freund masculin friend],
-  %w[mann masculin man],
-  %w[kellner masculin waiter],
-  %w[freundin feminin friend],
-  %w[stadt feminin city],
-  %w[hand feminin hand],
-  %w[hande plurial hands],
-  %w[teile plurial parts],
-  %w[manner plurial men],
-  %w[lander plurial countries],
-  %w[auto neutral car],
-  %w[jahr neutral year],
-  %w[beispiel neutral exemple],
-  %w[haus neutral house],
-  %w[end neutral end]
-  ]
-
-noun.each do |array|
-  Noun.create!(
-    value: array[0],
-    gender: array[1],
-    english: array[2]
-      )
-end
 
 %w[subject verb od oi preposition].each do |el|
   Element.create!(value: el)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
+  factory :verb_noun_link do
+    noun { nil }
+    verb { nil }
+  end
+
   factory :progress_tracker do
     counter { "MyString" }
   end

--- a/spec/models/noun_spec.rb
+++ b/spec/models/noun_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Noun, type: :model do
-  # pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    it { should have_many(:verb_noun_links) }
+    it { should have_many(:verbs) }
+  end
 end

--- a/spec/models/structure_element_spec.rb
+++ b/spec/models/structure_element_spec.rb
@@ -8,5 +8,7 @@ RSpec.describe StructureElement, type: :model do
 
   describe 'validations' do
     it { should validate_presence_of(:position)}
+    it { should validate_presence_of(:structure_id)}
+    it { should validate_presence_of(:element_id)}
   end
 end

--- a/spec/models/verb_noun_link_spec.rb
+++ b/spec/models/verb_noun_link_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe VerbNounLink, type: :model do
+  describe 'assocations' do
+    it { should belong_to(:verb) }
+    it { should belong_to(:noun) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:verb_id)}
+    it { should validate_presence_of(:noun_id)}
+  end
+end

--- a/spec/models/verb_spec.rb
+++ b/spec/models/verb_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Verb, type: :model do
-  # pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    it { should have_many(:verb_noun_links) }
+    it { should have_many(:nouns) }
+  end
 end


### PR DESCRIPTION
With this PR there is no more sentences that don't make sense "it buys the country" "it knows the hand'. To achieve this the following have been modified:

Noun models:
Added a variable 'is_a' for type of noun eg: food, animal, people etc

Verb models
Added a array variable 'go_with' that match every nouns the verb can work with

Added join Table verb_noun_links to match each one at seeding.

Modified the seed file to match the changes describe above.

Modified the SentenceBuilder service so the noun is picked depending on the pre-selected verb.