### PR TITLE
quick fix to separate the S_V_DO exercice with dative and accusative

### DIFF
--- a/app/services/sentence_builder_service.rb
+++ b/app/services/sentence_builder_service.rb
@@ -1,7 +1,8 @@
 class SentenceBuilderService
   def initialize(exercice)
-    @g_case = ['dative', 'accusative'].sample #NEED TO BE REPLACE BY AN OPTION INSIDE EXERCICE TABLE SO USER CAN SELECT DIFFERENT FORM OF EXERCISES
     @exercice = exercice
+    @g_case = @exercice.structure.name == 's_v_do_dative' ? 'dative' : 'accusative' #NEED TO BE REPLACE BY AN OPTION INSIDE EXERCICE TABLE SO USER CAN SELECT DIFFERENT FORM OF EXERCISES
+    @person = PersonalPronoun.all.map(&:person).uniq.sample
     @genders = Article.all.map(&:gender).uniq
     @gender = fetch_gender
   end
@@ -28,12 +29,11 @@ class SentenceBuilderService
   end
 
   def fetch_verb
-    @person
     if @noun.verbs.where(person: @person).empty?
-      return @noun.verbs.where(person: 'third_singular').sample
+      return @noun.verbs.where(person: 'third_singular', g_case: @g_case).sample
     end
 
-    @noun.verbs.where(person: @person).sample
+    @noun.verbs.where(person: @person, g_case: @g_case).sample
   end
 
   def fetch_article
@@ -69,5 +69,9 @@ class SentenceBuilderService
     german = "#{@verb.value} #{@subject.value} #{@article.value} #{@noun.value.capitalize}?"
     obfus = "#{@verb.value.capitalize} #{@subject.value} #{@article.value.split(//).map! { '_ ' }.join} #{@noun.value.capitalize}"
     { sentence: german, obfus: obfus, english: english, solution: @article.value }
+  end
+
+  def s_v_do_dative
+    s_v_do
   end
 end

--- a/app/views/exercices/show.html.erb
+++ b/app/views/exercices/show.html.erb
@@ -1,5 +1,6 @@
 <div class='main-container'>
   <h1><%= @exercice.name %></h1>
+
   <% if @exercice.result == true %>
   <div  class='success'>
     <p>GOOD JOB!</p>

--- a/db/migrate/20191115153029_add_option_to_exercices.rb
+++ b/db/migrate/20191115153029_add_option_to_exercices.rb
@@ -1,0 +1,5 @@
+class AddOptionToExercices < ActiveRecord::Migration[5.2]
+  def change
+      add_column :exercices, :option, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_12_164758) do
+ActiveRecord::Schema.define(version: 2019_11_15_153029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2019_11_12_164758) do
     t.string "solution"
     t.string "obfus"
     t.boolean "result"
+    t.string "option", array: true
     t.index ["structure_id"], name: "index_exercices_on_structure_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -247,7 +247,7 @@ end
   Element.create!(value: el)
 end
 
-%w[s_v_prep_do s_v_do v_s_do].each do |structure|
+%w[s_v_prep_do s_v_do v_s_do s_v_do_dative].each do |structure|
   Structure.create!(name: structure)
 end
 
@@ -272,17 +272,22 @@ end
 Exercice.create!(
   name: 'Sentence with direct object and accusative',
   description: 'simple sentence structure with accusative and direct object',
-  structure_id: Structure.find_by(name: 's_v_do').id
+  structure: Structure.find_by(name: 's_v_do')
   )
 Exercice.create!(
   name: 'Sentence with direct object and accusative with preposition',
   description: 'simple sentence structure with accusative and preposition',
-  structure_id: Structure.find_by(name: 's_v_prep_do').id
+  structure: Structure.find_by(name: 's_v_prep_do')
   )
 Exercice.create!(
   name: ' Questions with direct object and accusative',
   description: 'Questions with accusative and preposition',
-  structure_id: Structure.find_by(name: 'v_s_do').id
+  structure: Structure.find_by(name: 'v_s_do')
+  )
+Exercice.create!(
+  name: ' Sentence with direct object and dative',
+  description: 'Sentence with dative and preposition',
+  structure: Structure.find_by(name: 's_v_do_dative')
   )
 
 puts ' IT IS DONE! '


### PR DESCRIPTION
Added a simple conditional inside SentenceBuilder to let the user choose between accusative and dative for the s_v_do exercises. This will need a better architecture later on.