### PR TITLE
Exercice page: no success/failur message on new visit

### DIFF
--- a/app/controllers/exercices_controller.rb
+++ b/app/controllers/exercices_controller.rb
@@ -6,33 +6,30 @@ class ExercicesController < ApplicationController
   end
 
   def show
-    exercice_correction if params[:response]
     @exercice = Exercice.find(params[:id])
+    @exercice.result = false
+    exercice_correction if params[:response]
     @exercice.update_attributes SentenceBuilderService.new(@exercice).generate
     @exercice.save
-
-    # @progress_tracker = ProgressTracker.find_by(user: current_user, exercice: @exercice) || ProgressTracker.new
   end
 
   private
 
   def exercice_correction
-    @exercice = Exercice.find(params[:id])
-    @exercice.result = false
+    @exercice.result = true
     if params[:response]&.downcase == @exercice.solution[0]&.downcase && params[:response_2]&.downcase == @exercice.solution[1]&.downcase
-      successful_trial
+      successful_trial(true)
     elsif params[:response].downcase == @exercice.solution.first.downcase
-      successful_trial
+      successful_trial(true)
     else
-      Trial.create!(user: current_user, exercice: @exercice, success: false)
+      successful_trial(false)
     end
     @exercice.prev_sentence = @exercice.sentence
-    @exercice.save
-    redirect_to exercice_path(params[:id])
+    # @exercice.save
+    # redirect_to exercice_path(params[:id])
   end
 
-  def successful_trial
-    @exercice.result = true
-    Trial.create!(user: current_user, exercice: @exercice, success: true)
+  def successful_trial(success)
+    Trial.create!(user: current_user, exercice: @exercice, success: success)
   end
 end

--- a/app/views/exercices/show.html.erb
+++ b/app/views/exercices/show.html.erb
@@ -11,15 +11,19 @@
 
   <div class="exercice-container">
 
-    <% if success(current_user, @exercice) %>
-      <div  class='success mb-3'>
-        <p>GOOD JOB!</p>
-      </div>
-    <% elsif already_tried(current_user, @exercice) %>
-      <p>The answer was:  <%= @exercice.prev_sentence %></p>
-      <div  class='failure mb-3'>
-        <p> Try again, you'll get it right next time!</p>
-      </div>
+    <% if @exercice.result %>
+
+      <% if success(current_user, @exercice) %>
+        <div  class='success mb-3'>
+          <p>GOOD JOB!</p>
+        </div>
+
+      <% elsif already_tried(current_user, @exercice) %>
+        <p>The answer was:  <%= @exercice.prev_sentence %></p>
+        <div  class='failure mb-3'>
+          <p> Try again, you'll get it right next time!</p>
+        </div>
+      <% end %>
     <% end %>
 
     <p class="mt-5 font-weight-bold">The next exercise sentence is:</p>


### PR DESCRIPTION
When the user was coming back on an exercise page he was being shown the success/failure message from his/her last try. This PR fixes that problem. I also lightly refactored the exercice controller.