### PR TITLE
Hiding the elements of sentences better

### DIFF
--- a/app/controllers/exercices_controller.rb
+++ b/app/controllers/exercices_controller.rb
@@ -10,16 +10,15 @@ class ExercicesController < ApplicationController
     @exercice.result = false
     params[:response] ? exercice_correction : @exercice.streak = 0
     @exercice.update_attributes SentenceBuilderService.new(@exercice).generate
-    @exercice.save
   end
 
   private
 
   def exercice_correction
     @exercice.result = true
-    if params[:response]&.downcase == @exercice.solution[0]&.downcase &&
-       params[:response_2]&.downcase == @exercice.solution[1]&.downcase ||
-       params[:response].downcase == @exercice.solution.first.downcase && params[:response_2].nil?
+    if text_cleaner(params[:response]) == text_cleaner(@exercice.solution[0]) &&
+       text_cleaner(params[:response_2]) == text_cleaner(@exercice.solution[1]) ||
+       text_cleaner(params[:response]) == text_cleaner(@exercice.solution.first) && params[:response_2].nil?
       create_trial(true)
     else
       create_trial(false)
@@ -32,5 +31,9 @@ class ExercicesController < ApplicationController
   def create_trial(success)
     Trial.create!(user: current_user, exercice: @exercice, success: success)
     @exercice.streak = success ? @exercice.streak + 1 : 0
+  end
+
+  def text_cleaner(answer)
+    answer&.downcase&.strip
   end
 end

--- a/app/helpers/views_helper.rb
+++ b/app/helpers/views_helper.rb
@@ -42,4 +42,20 @@ module ViewsHelper
   def streak_congratulation
     ['Du bist der hammer!', 'Du bist MEGA geil!', 'bärenstark!'].sample
   end
+
+  def hide_answer(sentence, positions)
+    splited_sentence = sentence.split(' ')
+    positions.each do |position|
+      splited_sentence[position.to_i] = splited_sentence[position.to_i].split(//).map! { '_' }.join
+    end
+    splited_sentence.join(' ')
+  end
+
+  def highlight_solution(sentence, positions)
+    splited_sentence = sentence.split(' ')
+    positions.each do |position|
+      splited_sentence[position.to_i] = splited_sentence[position.to_i].upcase
+    end
+    splited_sentence.join(' ')
+  end
 end

--- a/app/services/sentence_builder_service.rb
+++ b/app/services/sentence_builder_service.rb
@@ -112,7 +112,7 @@ class SentenceBuilderService
     article = fetch_article(g_case, noun.gender)
     verb = fetch_verb(g_case, noun)
     { sentence: "#{subject.value.capitalize} #{verb.value} #{preposition.value} #{article.value} #{noun.value.capitalize}",
-      obfus: "#{subject.value.capitalize} #{verb.value} #{preposition.value} #{article.value.split(//).map! { '_' }.join} #{noun.value.capitalize}",
+      hide_index: [3], #{}"#{subject.value.capitalize} #{verb.value} #{preposition.value} #{article.value.split(//).map! { '_' }.join} #{noun.value.capitalize}",
       english: "#{subject.english.capitalize} #{verb.english} #{preposition.english} #{english_article(article, noun)} #{noun.english}",
       solution: [article.value] }
   end
@@ -123,7 +123,7 @@ class SentenceBuilderService
     article = fetch_article(g_case, noun.gender, negation: false)
     verb = fetch_verb(g_case, noun)
     { sentence: "#{verb.value.capitalize} #{subject.value} #{article.value} #{noun.value.capitalize}?",
-      obfus: "#{verb.value.capitalize} #{subject.value} #{article.value.split(//).map! { '_' }.join} #{noun.value.capitalize}",
+      hide_index: [2], #{}"#{verb.value.capitalize} #{subject.value} #{article.value.split(//).map! { '_' }.join} #{noun.value.capitalize}",
       english: "#{do_or_does(@person_verb)} #{subject.english} #{@person_verb == 'third_singular' ? remove_the_s(verb.english) : verb.english} #{english_article(article, noun)} #{noun.english}?",
       solution: [article.value] }
   end
@@ -137,7 +137,7 @@ class SentenceBuilderService
     do_article = fetch_article('accusative', noun.gender, negation: negation)
     verb = fetch_verb('accu_dati', noun)
     { sentence: "#{subject.value.capitalize} #{verb.value} #{io_article.value} #{io_noun.value} #{do_article.value} #{noun.value.capitalize} #{nicht_or_not(do_article)}",
-      obfus: "#{subject.value.capitalize} #{verb.value} #{io_article.value.split(//).map! { '_' }.join} #{io_noun.value.capitalize} #{do_article.value.split(//).map! { '_' }.join} #{noun.value.capitalize} #{nicht_or_not(do_article)}",
+      hide_index: [2, 4], #"#{subject.value.capitalize} #{verb.value} #{io_article.value.split(//).map! { '_' }.join} #{io_noun.value.capitalize} #{do_article.value.split(//).map! { '_' }.join} #{noun.value.capitalize} #{nicht_or_not(do_article)}",
       english: "#{subject.english.capitalize} #{negation ? dont_or_doesnt(@person_verb, verb) : verb.english} #{english_article(do_article, noun)} #{noun.english} #{io_article.definite ? io_article.english : a_or_an(io_noun, 'dative')} #{io_noun.english}",
       solution: [io_article.value, do_article.value] }
   end
@@ -145,14 +145,14 @@ class SentenceBuilderService
   def conjug
     verb = Verb.where(person: @person_verb).sample
     { sentence: "#{@subject.value.capitalize} #{verb.value}",
-      obfus: "#{@subject.value.capitalize} #{verb.value.split(//).map! { '_ ' }.join}",
+      hide_index: [1], #{}"#{@subject.value.capitalize} #{verb.value.split(//).map! { '_ ' }.join}",
       english: "#{@subject.english.capitalize} #{verb.english}",
       solution: [verb.value] }
   end
 
   def fetch_sentence(subject, verb, article, noun)
     { sentence: "#{subject.value.capitalize} #{verb.value} #{article.value} #{noun.value.capitalize} #{nicht_or_not(article)}",
-      obfus: "#{subject.value.capitalize} #{verb.value} #{article.value.split(//).map! { '_' }.join} #{noun.value.capitalize} #{nicht_or_not(article)} ",
+      hide_index: [2], #"#{subject.value.capitalize} #{verb.value} #{article.value.split(//).map! { '_' }.join} #{noun.value.capitalize} #{nicht_or_not(article)} ",
       english: "#{subject.english.capitalize} #{article.negation ? dont_or_doesnt(@person_verb, verb) : verb.english} #{english_article(article, noun)} #{noun.english}",
       solution: [article.value] }
   end

--- a/app/services/sentence_builder_service.rb
+++ b/app/services/sentence_builder_service.rb
@@ -7,7 +7,6 @@ class SentenceBuilderService
     @person = PersonalPronoun.all.map(&:person).uniq.sample
     @person_verb = fetch_person_verb(@person)
     @gender = fetch_gender
-    # @definite_article = true if @exercice.structure.name.include?('prep')
   end
 
   def generate
@@ -112,7 +111,7 @@ class SentenceBuilderService
     article = fetch_article(g_case, noun.gender)
     verb = fetch_verb(g_case, noun)
     { sentence: "#{subject.value.capitalize} #{verb.value} #{preposition.value} #{article.value} #{noun.value.capitalize}",
-      hide_index: [3], #{}"#{subject.value.capitalize} #{verb.value} #{preposition.value} #{article.value.split(//).map! { '_' }.join} #{noun.value.capitalize}",
+      hide_index: [3],
       english: "#{subject.english.capitalize} #{verb.english} #{preposition.english} #{english_article(article, noun)} #{noun.english}",
       solution: [article.value] }
   end
@@ -123,7 +122,7 @@ class SentenceBuilderService
     article = fetch_article(g_case, noun.gender, negation: false)
     verb = fetch_verb(g_case, noun)
     { sentence: "#{verb.value.capitalize} #{subject.value} #{article.value} #{noun.value.capitalize}?",
-      hide_index: [2], #{}"#{verb.value.capitalize} #{subject.value} #{article.value.split(//).map! { '_' }.join} #{noun.value.capitalize}",
+      hide_index: [2],
       english: "#{do_or_does(@person_verb)} #{subject.english} #{@person_verb == 'third_singular' ? remove_the_s(verb.english) : verb.english} #{english_article(article, noun)} #{noun.english}?",
       solution: [article.value] }
   end
@@ -137,7 +136,7 @@ class SentenceBuilderService
     do_article = fetch_article('accusative', noun.gender, negation: negation)
     verb = fetch_verb('accu_dati', noun)
     { sentence: "#{subject.value.capitalize} #{verb.value} #{io_article.value} #{io_noun.value} #{do_article.value} #{noun.value.capitalize} #{nicht_or_not(do_article)}",
-      hide_index: [2, 4], #"#{subject.value.capitalize} #{verb.value} #{io_article.value.split(//).map! { '_' }.join} #{io_noun.value.capitalize} #{do_article.value.split(//).map! { '_' }.join} #{noun.value.capitalize} #{nicht_or_not(do_article)}",
+      hide_index: [2, 4],
       english: "#{subject.english.capitalize} #{negation ? dont_or_doesnt(@person_verb, verb) : verb.english} #{english_article(do_article, noun)} #{noun.english} #{io_article.definite ? io_article.english : a_or_an(io_noun, 'dative')} #{io_noun.english}",
       solution: [io_article.value, do_article.value] }
   end
@@ -145,14 +144,14 @@ class SentenceBuilderService
   def conjug
     verb = Verb.where(person: @person_verb).sample
     { sentence: "#{@subject.value.capitalize} #{verb.value}",
-      hide_index: [1], #{}"#{@subject.value.capitalize} #{verb.value.split(//).map! { '_ ' }.join}",
+      hide_index: [1],
       english: "#{@subject.english.capitalize} #{verb.english}",
       solution: [verb.value] }
   end
 
   def fetch_sentence(subject, verb, article, noun)
     { sentence: "#{subject.value.capitalize} #{verb.value} #{article.value} #{noun.value.capitalize} #{nicht_or_not(article)}",
-      hide_index: [2], #"#{subject.value.capitalize} #{verb.value} #{article.value.split(//).map! { '_' }.join} #{noun.value.capitalize} #{nicht_or_not(article)} ",
+      hide_index: [2],
       english: "#{subject.english.capitalize} #{article.negation ? dont_or_doesnt(@person_verb, verb) : verb.english} #{english_article(article, noun)} #{noun.english}",
       solution: [article.value] }
   end

--- a/app/views/exercices/show.html.erb
+++ b/app/views/exercices/show.html.erb
@@ -16,7 +16,7 @@
           <p>GOOD JOB!</p>
         </div>
       <% elsif already_tried(current_user, @exercice) %>
-        <p>The answer was:  <%= @exercice.prev_sentence %></p>
+        <p>The answer was:  <%= highlight_solution(@exercice.prev_sentence, @exercice.hide_index) %></p>
         <p>You answered: <%= @answer_one %> <%= "and #{@answer_two}" if @answer_two %> </p>
         <div  class='failure mb-3'>
           <p> Try again, you'll get it right next time!</p>
@@ -38,7 +38,7 @@
     <p class="mt-3 font-weight-bold">The next exercise sentence is:</p>
     <p><%= @exercice.english %></p>
     <p>
-    <%= @exercice.obfus %>
+    <%= hide_answer(@exercice.sentence, @exercice.hide_index) %>
     <% if already_tried(current_user, @exercice) %>
       <%= form_with(url: "/exercice_try/#{@exercice.id}", method: 'post', local: true, html: { autocomplete: "off" }) do %>
         <%= hidden_field_tag sentence: @exercice.sentence  %>

--- a/db/migrate/20191205135125_change_obfus_from_exercices.rb
+++ b/db/migrate/20191205135125_change_obfus_from_exercices.rb
@@ -1,0 +1,5 @@
+class ChangeObfusFromExercices < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :exercices, :obfus, :string
+  end
+end

--- a/db/migrate/20191205140040_add_hide_index_to_exercices.rb
+++ b/db/migrate/20191205140040_add_hide_index_to_exercices.rb
@@ -1,0 +1,5 @@
+class AddHideIndexToExercices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :exercices, :hide_index, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_04_142428) do
+ActiveRecord::Schema.define(version: 2019_12_05_140040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,10 +41,10 @@ ActiveRecord::Schema.define(version: 2019_12_04_142428) do
     t.string "sentence"
     t.string "prev_sentence"
     t.string "english"
-    t.string "obfus"
     t.boolean "result"
     t.string "solution", array: true
     t.integer "streak"
+    t.string "hide_index", array: true
     t.index ["structure_id"], name: "index_exercices_on_structure_id"
   end
 

--- a/spec/services/direct_and_indirect_object_spec.rb
+++ b/spec/services/direct_and_indirect_object_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe 'Exercise with direct and indirect object' do
     expect(@result[:english].split(' ').length).to eq(7)
   end
 
-  it 'the obfuscated should be composed of 6 elements' do
-    expect(@result[:obfus].split(' ').length).to eq(6)
+  it 'the obfuscated elements should match the solution' do
+    expect(@result[:sentence].split(' ')[@result[:hide_index][0]]).to eq(@result[:solution][0])
   end
 
   it 'the first article should be dative' do


### PR DESCRIPTION
This PR achieve 3 things:
-The article is not hidden through another sentence already hiding but through an index in the view. This will allow late for hidden more stuff easily(e.g. the verb)
-Remove white space from the user's answer
-When the user is wrong the correction is shown up cased the article so the user can see better what was wrong with his/her answer.