### PR TITLE
Personal_pronouns to pronouns and added kind category

### DIFF
--- a/app/models/personal_pronoun.rb
+++ b/app/models/personal_pronoun.rb
@@ -1,7 +1,0 @@
-class PersonalPronoun < ApplicationRecord
-  validates :value, inclusion: { in: %w[ich du er sie es wir ihr Sie mich dich ihn uns euch mir dir ihm ihr ihnen],
-                                 message: 'Not a valid German personal pronoun' }
-  def to_s
-   value
-  end
-end

--- a/app/models/pronoun.rb
+++ b/app/models/pronoun.rb
@@ -1,0 +1,5 @@
+class Pronoun < ApplicationRecord
+  def to_s
+   value
+  end
+end

--- a/app/services/sentence_builder_service.rb
+++ b/app/services/sentence_builder_service.rb
@@ -4,7 +4,7 @@ class SentenceBuilderService
     @exercice = exercice
     @vowel = ('aeiou')
     @g_case = @exercice.structure.name == 's_v_do_dative' ? 'dative' : 'accusative'
-    @person = PersonalPronoun.all.map(&:person).uniq.sample
+    @person = Pronoun.where(kind: 'personal').map(&:person).uniq.sample
     @person_verb = fetch_person_verb(@person)
     @gender = fetch_gender
   end
@@ -57,7 +57,7 @@ class SentenceBuilderService
   end
 
   def fetch_subject
-    personal_pronoun = PersonalPronoun.find_by(person: @person)
+    personal_pronoun = Pronoun.find_by(person: @person, kind: 'personal')
     raise "No personal pronoun found with person #{@person}" if personal_pronoun.nil?
 
     personal_pronoun

--- a/db/migrate/20191207122248_rename_personal_pronouns_to_pronouns.rb
+++ b/db/migrate/20191207122248_rename_personal_pronouns_to_pronouns.rb
@@ -1,0 +1,5 @@
+class RenamePersonalPronounsToPronouns < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :personal_pronouns, :pronouns
+  end
+end

--- a/db/migrate/20191207124528_add_kind_to_pronouns.rb
+++ b/db/migrate/20191207124528_add_kind_to_pronouns.rb
@@ -1,0 +1,5 @@
+class AddKindToPronouns < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pronouns, :kind, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_07_105537) do
+ActiveRecord::Schema.define(version: 2019_12_07_124528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,15 +55,6 @@ ActiveRecord::Schema.define(version: 2019_12_07_105537) do
     t.string "kind"
   end
 
-  create_table "personal_pronouns", force: :cascade do |t|
-    t.string "value"
-    t.string "person"
-    t.string "g_case"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "english"
-  end
-
   create_table "prepositions", force: :cascade do |t|
     t.string "value"
     t.string "g_case"
@@ -78,6 +69,16 @@ ActiveRecord::Schema.define(version: 2019_12_07_105537) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "counter"
+  end
+
+  create_table "pronouns", force: :cascade do |t|
+    t.string "value"
+    t.string "person"
+    t.string "g_case"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "english"
+    t.string "kind"
   end
 
   create_table "structure_elements", force: :cascade do |t|

--- a/db/seeds/pronouns.seeds.rb
+++ b/db/seeds/pronouns.seeds.rb
@@ -1,17 +1,18 @@
-pp = [%w[ich first_singular nominative I],
-      %w[du second_singular nominative you],
-      %w[er third_masculin nominative he],
-      %w[sie third_feminin nominative she],
-      %w[wir first_plurial nominative we],
-      %w[ihr second_plurial nominative you],
-      %w[Sie third_plurial nominative they],
+pp = [%w[ich first_singular nominative I personal],
+      %w[du second_singular nominative you personal],
+      %w[er third_masculin nominative he personal],
+      %w[sie third_feminin nominative she personal],
+      %w[wir first_plurial nominative we personal],
+      %w[ihr second_plurial nominative you personal],
+      %w[Sie third_plurial nominative they personal],
   ]
 pp.each do |array|
-  PersonalPronoun.find_or_create_by!(
+  Pronoun.find_or_create_by!(
     value: array[0],
     person: array[1],
     g_case: array[2],
-    english: array[3]
+    english: array[3],
+    kind: array[4]
       )
 end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -67,11 +67,12 @@ FactoryBot.define do
     end
   end
 
-  factory :personal_pronoun do
+  factory :pronoun, aliases: [:personal_pronoun] do
     value { 'sie' }
     person { 'third_feminin' }
     g_case { 'nominative' }
     english { 'she' }
+    kind { 'personal' }
 
     trait :first_singular_nominative do
       value { 'ich' }

--- a/spec/models/personal_pronoun_spec.rb
+++ b/spec/models/personal_pronoun_spec.rb
@@ -1,4 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe PersonalPronoun, type: :model do
-end

--- a/test/models/german_personal_pronoun_test.rb
+++ b/test/models/german_personal_pronoun_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class GermanPersonalPronounTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
In preparation for adding possessive pronouns this PR:
-Rename table and model form personal_pronouns to pronouns and associated changed through out the app.
-Add a kind column to the same table/model to specify 'personal', possessive', etc